### PR TITLE
date time formatting

### DIFF
--- a/finance_management_app/README.md
+++ b/finance_management_app/README.md
@@ -72,6 +72,70 @@ Containers vs Column / Row
 |Flexible width (e.g child width, available width, ...)| Always takes full available height (column) / width (row)
 |Perfect for custom styling & alignment | Must-use if widgets sit next to/ above each other
 
+Date Formatting
+-
+
+- Required package: [intl](https://pub.dev/packages/intl)
+
+DateFormat Patterns
+-
+
+- The [intl](https://pub.dev/packages/intl) package supports a broad range of date formatting patterns. Here's a list (taken from the official docs):
+
+|DAY           |               d|
+|--------------------|------------|
+ |ABBR_WEEKDAY              |   E|
+ |WEEKDAY            |          EEEE|
+ |ABBR_STANDALONE_MONTH  |      LLL|
+ |STANDALONE_MONTH     |        LLLL|
+ |NUM_MONTH          |          M||
+ |NUM_MONTH_DAY    |            Md|
+ |NUM_MONTH_WEEKDAY_DAY  |      MEd|
+ |ABBR_MONTH          |         MMM|
+ |ABBR_MONTH_DAY     |          MMMd|
+ |ABBR_MONTH_WEEKDAY_DAY   |    MMMEd|
+ |MONTH                 |       MMMM|
+ |MONTH_DAY               |     MMMMd|
+ |MONTH_WEEKDAY_DAY        |    MMMMEEEEd|
+ |ABBR_QUARTER      |           QQQ|
+ |QUARTER            |          QQQQ|
+ |YEAR                |         y|
+ |YEAR_NUM_MONTH       |        yM|
+ |YEAR_NUM_MONTH_DAY    |       yMd|
+ |YEAR_NUM_MONTH_WEEKDAY_DAY|   yMEd|
+ |YEAR_ABBR_MONTH       |       yMMM|
+ |YEAR_ABBR_MONTH_DAY    |      yMMMd|
+ |YEAR_ABBR_MONTH_WEEKDAY_DAY|  yMMMEd|
+ |YEAR_MONTH        |           yMMMM|
+ |YEAR_MONTH_DAY     |          yMMMMd|
+ |YEAR_MONTH_WEEKDAY_DAY|       yMMMMEEEEd|
+ |YEAR_ABBR_QUARTER      |      yQQQ|
+ |YEAR_QUARTER            |     yQQQQ|
+ |HOUR24                   |    H|
+ |HOUR24_MINUTE             |   Hm|
+ |HOUR24_MINUTE_SECOND|         Hms|
+ |HOUR                 |        j|
+ |HOUR_MINUTE           |       jm|
+ |HOUR_MINUTE_SECOND     |      jms|
+ |HOUR_MINUTE_GENERIC_TZ  |     jmv|
+ |HOUR_MINUTE_TZ           |    jmz|
+ |HOUR_GENERIC_TZ           |   jv|
+ |HOUR_TZ                    |  jz|
+ |MINUTE        |               m|
+ |MINUTE_SECOND  |              ms|
+ |SECOND          |             s|
+
+
+Examples Using the US Locale:
+
+ |Pattern                |     |      Result|
+ |----------------     |  ---- |          -------|
+ |new DateFormat.yMd()          |   -> |7/10/1996|
+| new DateFormat("yMd")          |  -> |7/10/1996|
+| new DateFormat.yMMMMd("en_US") |  -> |July 10, 1996|
+| new DateFormat.jm()            |  -> |5:08 PM|
+| new DateFormat.yMd().add_jm()  |  -> |7/10/1996 5:08 PM|
+| new DateFormat.Hm()            |  ->| 17:08 // force 24 hour time|
 
 Resources
 -

--- a/finance_management_app/lib/main.dart
+++ b/finance_management_app/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import './transaction.dart';
 
 void main() => runApp(MyApp());
@@ -73,7 +74,7 @@ class MyHomePage extends StatelessWidget {
                       ),
                       padding: EdgeInsets.all(8),
                       child: Text(
-                        transX.amount.toString(),
+                        '\$ ${transX.amount}',
                         style: TextStyle(
                           fontSize: 20,
                           fontWeight: FontWeight.bold,
@@ -93,7 +94,8 @@ class MyHomePage extends StatelessWidget {
                           ),
                         ),
                         Text(
-                          transX.date.toString(),
+                          // DateFormat('dd-MM-yyyy').format(transX.date),
+                          DateFormat.yMMMMd().format(transX.date),
                           style: TextStyle(
                             fontSize: 15,
                             fontWeight: FontWeight.bold,

--- a/finance_management_app/pubspec.lock
+++ b/finance_management_app/pubspec.lock
@@ -67,6 +67,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: "direct dev"
+    description:
+      name: intl
+      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.0"
   js:
     dependency: transitive
     description:

--- a/finance_management_app/pubspec.yaml
+++ b/finance_management_app/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  intl: ^0.18.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
- The [intl](https://pub.dev/packages/intl) package supports a broad range of date formatting patterns. Here's a list (taken from the official docs):

Examples Using the US Locale:

 |Pattern                |     |      Result|
 |----------------     |  ---- |          -------|
 |new DateFormat.yMd()          |   -> |7/10/1996|
| new DateFormat("yMd")          |  -> |7/10/1996|
| new DateFormat.yMMMMd("en_US") |  -> |July 10, 1996|
| new DateFormat.jm()            |  -> |5:08 PM|
| new DateFormat.yMd().add_jm()  |  -> |7/10/1996 5:08 PM|
| new DateFormat.Hm()            |  ->| 17:08 // force 24 hour time|